### PR TITLE
Return early when catching CiviCRM API call exception in local connector.

### DIFF
--- a/CMRF/Connection/Local.php
+++ b/CMRF/Connection/Local.php
@@ -34,6 +34,7 @@ class Local extends Connection {
         $this->getAPI3Params($call));      
     } catch (\Exception $e) {
       $call->setStatus(Call::STATUS_FAILED, $e->getMessage());
+      return $call->getReply();
     }
 
     // Hack from CiviCRM core to make the reply behave similar as the remote API.


### PR DESCRIPTION
In order to not overwrite the call's reply with code after the catch branch, return the call's reply early.