### PR TITLE
Bring autoload definition in sync with the drupal cmrf_core module

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "CiviMRF/CMRF_Abstract_Core",
     "autoload": {
         "psr-0" : {
-            "CMRF" : "CMRF"
+            "CMRF" : ""
         }
     }
 }


### PR DESCRIPTION
The definition is now the same as in https://github.com/CiviMRF/cmrf_core/blob/8.x-dev/composer.json and https://github.com/CiviMRF/cmrf-wordpress/blob/master/composer.json 

