### PR TITLE
SQLPersistingCallFactory: Use variable which can be passed as reference in bind_param()

### DIFF
--- a/CMRF/PersistenceLayer/SQLPersistingCallFactory.php
+++ b/CMRF/PersistenceLayer/SQLPersistingCallFactory.php
@@ -138,10 +138,11 @@ class SQLPersistingCallFactory extends CallFactory {
     if (!empty($options['cache'])) {
       $today = new \DateTime();
       $today = $today->format('Y-m-d H:i:s');
+      $hash = $call->getHash();
       $stmt = $this->connection->prepare(
         "select * from {$this->table_name} where request_hash = ? and connector_id = ? and cached_until > ? limit 1"
       );
-      $stmt->bind_param('sss', $call->getHash(), $connector_id, $today);
+      $stmt->bind_param('sss', $hash, $connector_id, $today);
       $stmt->execute();
 
       $result = $stmt->get_result();


### PR DESCRIPTION
Parameters to be bound need to be passed as reference in `bind_param()`.