### PR TITLE
Fail the CMRF call if no response could be retrieved

### DIFF
--- a/CMRF/Connection/AbstractCurlConnection.php
+++ b/CMRF/Connection/AbstractCurlConnection.php
@@ -44,7 +44,7 @@ abstract class AbstractCurlConnection extends Connection {
     $curl = $this->createCurl($call);
 
     $response = curl_exec($curl);
-    if ('' !== curl_error($curl)){
+    if (FALSE === $response || '' !== curl_error($curl)){
       $call->setStatus(Call::STATUS_FAILED, curl_error($curl), curl_errno($curl));
       return NULL;
     } else {


### PR DESCRIPTION
If `curl_exec()` fails without an error message (`curl_error()` still returning the empty string, but `curl_exec()` returning `FALSE`), do not try to `json_decode()` the response, as this crashes the application.

Failing to execute the cURL request should result in a `Call::STATUS_FAILED`.

Can someone explain which scenarios might lead to this behavior? I saw a cURL error code 77, but maybe there's more to cater for …