### PR TITLE
Allow overriding cURL options in the profile

### DIFF
--- a/CMRF/Connection/AbstractCurlConnection.php
+++ b/CMRF/Connection/AbstractCurlConnection.php
@@ -79,6 +79,18 @@ abstract class AbstractCurlConnection extends Connection {
     curl_setopt($curl, CURLOPT_SSL_VERIFYPEER, FALSE);
     curl_setopt($curl, CURLOPT_SSL_VERIFYHOST, FALSE);
 
+    $profile = $this->getProfile();
+    foreach ($profile['curl_options'] ?? [] as $constant => $value) {
+      try {
+        if (NULL !== ($option = @constant($constant))) {
+          curl_setopt($curl, $option, $value);
+        }
+      }
+      catch (\Error $error) {
+        // Ignore invalid cURL options.
+      }
+    }
+
     return $curl;
   }
 


### PR DESCRIPTION
This allows global *cURL* options be overridden by a profile attribute `curl_options`, which should be an array of *cURL* option names as keys (will be resolved to the particular constant).

This will e.g. allow for a configurable `CURLOPT_TIMEOUT`.