### PR TITLE
Support Address validate API calls

### DIFF
--- a/CMRF/Core/AbstractCall.php
+++ b/CMRF/Core/AbstractCall.php
@@ -210,7 +210,11 @@ abstract class AbstractCall implements CallInterface {
     }
 
     foreach (self::$protected as $field_name) {
-      if (isset($request[$field_name])) {
+      if ($field_name == 'action' && ($request['action'] ?? NULL) != ($this->getAction()) ) {
+        // Some actions may expect an 'action' key in the request parameters (e.g. "validate"),
+        // so don't filter that out if 'action' and '$request['action]' are different
+        continue;
+      } elseif (isset($request[$field_name])) {
         unset($request[$field_name]);
       }
     }

--- a/CMRF/Core/AbstractCall.php
+++ b/CMRF/Core/AbstractCall.php
@@ -88,7 +88,9 @@ abstract class AbstractCall implements CallInterface {
   }
 
   public function getHash() {
-    $request = $this->getRequest();
+    // Include Entity and Action in the request hash to ensure cached dataset retrieval 
+    // actually returns the expected values
+    $request = [ $this->getEntity(), $this->getAction(), $this->getRequest() ];
     self::normaliseArray($request);
     return sha1(json_encode($request));
   }


### PR DESCRIPTION
Address validation expects an Action and an action parameter.

```
$result = civicrm_api3('Address', 'validate', [
  'action' => "create",
  'contact_id' => $contact_id,
  'location_type_id' => $location_type_id,
]);
```

This allows 'action' key (API action) to be included in the $request for the validate Action.

Also fixes caching. API validation (and all other API calls) won't work correctly when the cache option is enabled, since the cached table returns results for API calls with the same request parameters, even if Entity and Action are different. This is because the request hash is being built ONLY using the request parameters.

Now Entity and Action are added back into the request hash.