### PR TITLE
Fix cached results request hash

### DIFF
--- a/CMRF/Core/AbstractCall.php
+++ b/CMRF/Core/AbstractCall.php
@@ -88,7 +88,9 @@ abstract class AbstractCall implements CallInterface {
   }
 
   public function getHash() {
-    $request = $this->getRequest();
+    // Include Entity and Action in the request hash to ensure cached dataset retrieval 
+    // actually returns the expected values
+    $request = [ $this->getEntity(), $this->getAction(), $this->getRequest() ];
     self::normaliseArray($request);
     return sha1(json_encode($request));
   }


### PR DESCRIPTION
Submitting PR for just this change. See discussion in #23 

> Also fixes caching. API validation (and all other API calls) won't work correctly when the cache option is enabled, since the cached table returns results for API calls with the same request parameters, even if Entity and Action are different. This is because the request hash is being built ONLY using the request parameters.
> 
> Now Entity and Action are added back into the request hash.

Agileware ref GFCV-80